### PR TITLE
chore: exclude *.local files from Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,6 +11,7 @@ coverage
 .vite
 .env
 .env.*
+*.local
 !.env.example
 specs
 .specify


### PR DESCRIPTION
Small follow-up: adds \`*.local\` to .dockerignore, matching the existing .gitignore pattern.

Also serves to re-trigger the publish workflow now that repo workflow permissions have been updated to read/write, and to produce a second merge to main for validating image tag traceability/retention.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>